### PR TITLE
Add column names to database results 

### DIFF
--- a/growus/growus.py
+++ b/growus/growus.py
@@ -78,14 +78,13 @@ def api_exercises_clear():
 	return 'deleted exercises from user ' + str(user_id)
 
 # show all exercises associated with a user (uses fetchall method. consider cursor method)
-@app.route("/exercises/all", methods = ["GET"])
-def api_exercises_all():
-	user_id = request.form['userId']
-
+# http://flask.pocoo.org/docs/0.12/api/#url-route-registrations
+@app.route("/exercises/<user_id>", methods = ["GET"])
+def api_exercises_all(user_id):
 	linkdata = models.show_all_exercises(user_id)
-	all_exercises = { "all_exercises" : linkdata }
-	
-	js = json.dumps(all_exercises)
+	exercises = { "exercises" : linkdata }
+
+	js = json.dumps(exercises)
 	response = Response(js, status=200, mimetype="application/json")
 	return response
 

--- a/growus/models.py
+++ b/growus/models.py
@@ -1,4 +1,24 @@
+from flask import g
 import sqlite3
+
+DATABASE = 'database.db'
+
+
+# Getting database responses as dicts mapped with column names (instead of tuples)
+# http://flask.pocoo.org/docs/1.0/patterns/sqlite3/
+def get_db():
+    def make_dicts(cursor, row):
+        return dict((cursor.description[idx][0], value)
+        for idx, value in enumerate(row))
+
+    db = getattr(g, '_database', None)
+
+    if db is None:
+        db = g._database = sqlite3.connect(DATABASE)
+
+    db.row_factory = make_dicts
+    return db
+
 
 def insert_exercise(exercise_type, user_id, name, description):
     # check if type is within the enum range
@@ -19,7 +39,7 @@ def delete_all_exercises(user_id):
     return
 
 def show_all_exercises(user_id):
-    with sqlite3.connect("database.db") as con:
+    with get_db() as con:
         cur = con.cursor()
         # check if user id exists
         cur.execute("SELECT * FROM Exercises WHERE OwnerId = ?", (user_id))


### PR DESCRIPTION
This is to structure the database results into dicts with column names and values, instead of the default tuple, so it is easier to work with!

before, a result was a tuple like this, no column names:

```
[(7, '1', 2, 'climbing', 'climb at the gym!')]
```

after you get something that is more friendly to read (looks like json format):
```
  {
    "Id": 4,
    "Type": "1",
    "OwnerId": 1,
    "Name": "climbing",
    "Description": "climb at the gym!"
  }
```

Second change: The `exercise/all` endpoint is a `get` request, so you can't give it request params. So we pass in the `user_id` from the url instead (: