### PR TITLE
Workout editor, Exercise list, and site header cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { User as FirebaseUser } from "firebase/app";
 
 import { auth } from "./Auth";
 import { getUser } from "./Database";
-import UserBadge from "./User";
+import { UserIcon } from "./User";
 
 const EMPTY_USER = {
   username: "",
@@ -75,11 +75,11 @@ class App extends React.Component {
     return (
       <div className="App">
         <header>
-          <div className="container">
+          <div className="container row-with-icon">
             <a href="/">
-            <h2>
-              let's grow us <img src={logo} className="App-logo" alt="logo" />
-            </h2>
+              <h1>
+                let's grow us <img src={logo} className="App-logo" alt="logo" />
+              </h1>
             </a>
             <NavBar user={userData} />
           </div>
@@ -104,9 +104,5 @@ const NavBar = ({ user }) => {
   if (!user || !user.displayName) {
     return null;
   }
-  return (
-    <div>
-      <UserBadge {...user} size={30} />
-    </div>
-  );
+  return <UserIcon {...user} size={30} />;
 };

--- a/src/Exercises.tsx
+++ b/src/Exercises.tsx
@@ -47,19 +47,57 @@ export default class Exercises extends React.PureComponent {
           <button type="submit">create</button>
         </form>
         <h3>Your exercises</h3>
-        <ul>
-          {exercises.map((exercise: Exercise, index) => {
-            return (
-              <li key={index}>
-                <div>
-                  <b>{exercise.name}</b>
-                </div>
-                <div>{exercise.description}</div>
-              </li>
-            );
-          })}
-        </ul>
+        <ExerciseList
+          exercises={exercises}
+        />
       </div>
     );
   }
 }
+
+export const ExerciseList = ({
+  exercises,
+  onDelete,
+  onEdit
+}: {
+  exercises: Array<Exercise>;
+  onDelete?: (id) => void;
+  onEdit?: (exercise: Exercise) => void;
+}) => (
+  <ul className="description-list">
+    {exercises.map((exercise: Exercise, index) => {
+      return (
+        <li key={index}>
+          <ExerciseDisplay {...exercise} />
+          {(onEdit || onDelete) && (
+            <div>
+              {onEdit && (
+                <button
+                  className="text-button icon-button"
+                  onClick={() => onEdit(exercise)}
+                >
+                  ✎
+                </button>
+              )}
+              {onDelete && (
+                <button
+                  className="text-button icon-button"
+                  onClick={() => onDelete(exercise.id)}
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+export const ExerciseDisplay = ({ name, description }: Exercise) => (
+  <div>
+    <b style={{ display: "block" }}>{name}</b>
+    <div className="description">{description}</div>
+  </div>
+);

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -38,7 +38,7 @@ const UserBadge = ({
 );
 export default UserBadge;
 
-const UserIcon = ({ displayName, imgSrc, size, username }) => (
+export const UserIcon = ({ displayName, imgSrc, size, username }) => (
   <img
     className="user-icon"
     src={imgSrc || ""}

--- a/src/Workouts.tsx
+++ b/src/Workouts.tsx
@@ -8,6 +8,7 @@ import {
   updateWorkout
 } from "./Database";
 import ColorPicker, { ColorSquare } from "./ColorPicker";
+import { ExerciseList } from "./Exercises";
 
 const WORKOUT_COLORS = [
   "ffdbb9",
@@ -62,18 +63,22 @@ export default class Workouts extends React.PureComponent {
     const { exerciseBank, workouts } = this.state;
 
     return (
-      <div>
-        <h3>New workout</h3>
-        <EditWorkout workout={NEW_WORKOUT} exerciseBank={exerciseBank} />
-        <h3>Your workouts :)</h3>
-        {workouts.map((workout: Workout) => (
-          <EditWorkout
-            key={workout.title}
-            workout={workout}
-            exerciseBank={exerciseBank}
-          />
-        ))}
-      </div>
+      <React.Fragment>
+        <section>
+          <h3>New workout</h3>
+          <EditWorkout workout={NEW_WORKOUT} exerciseBank={exerciseBank} />
+        </section>
+        <section>
+          <h3>Your workouts :)</h3>
+          {workouts.map((workout: Workout) => (
+            <EditWorkout
+              key={workout.title}
+              workout={workout}
+              exerciseBank={exerciseBank}
+            />
+          ))}
+        </section>
+      </React.Fragment>
     );
   }
 }
@@ -157,81 +162,64 @@ class EditWorkout extends React.PureComponent<
     );
 
     return (
-      <div className="section workout">
+      <section className="workout">
         {error && <p className="error">{error}</p>}
-        <form onSubmit={this.handleCreateWorkout}>
-          <label>
-            <input
-              type="text"
-              name="title"
-              defaultValue={workout && workout.title}
-              placeholder="workout name"
+        <div className="workout-badge">
+          <ColorPicker
+            colors={WORKOUT_COLORS}
+            color={color}
+            onColorClick={this.handleColorPick}
+            lineHeight={30}
+            size={20}
+          />
+          <form onSubmit={this.handleCreateWorkout}>
+            <label>
+              <input
+                type="text"
+                name="title"
+                defaultValue={workout && workout.title}
+                placeholder="workout name"
+              />
+            </label>
+            <label>
+              <input
+                type="text"
+                name="description"
+                defaultValue={workout && workout.description}
+                placeholder="workout description"
+              />
+            </label>
+            <ExerciseList
+              exercises={workoutExercises}
+              onDelete={this.removeExercise}
             />
-          </label>
-          <label>
-            <input
-              type="text"
-              name="description"
-              defaultValue={workout && workout.description}
-              placeholder="workout description"
-            />
-          </label>
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <span>Color marker: </span>
-            <ColorPicker
-              colors={WORKOUT_COLORS}
-              color={color}
-              onColorClick={this.handleColorPick}
-            />
-          </div>
-          <h4>exercises:</h4>
-          <ul>
-            {workoutExercises.map((exercise, index) => {
-              return (
-                <li key={index}>
-                  <div>
-                    <b>{exercise.name}</b>
-                  </div>
-                  <div>{exercise.description}</div>
-                  <button
-                    className="text-button"
-                    onClick={() => this.removeExercise(exercise.id)}
-                  >
-                    x
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-          <label>
-            Add exercises:
-            <select
-              name="exercise"
-              id="exercise-select"
-              onChange={this.addExercise}
-            >
-              <option value=""></option>
-              {availableExercises.map((exercise: Exercise, index) => {
-                return (
-                  <option key={index} value={exercise.id}>
-                    {exercise.name}
-                    {exercise.description && " - "}
-                    {exercise.description}
-                  </option>
-                );
-              })}
-            </select>
-          </label>
-          <div>
-            <button type="submit">
-              {workout.id ? "update" : "create"} workout
-            </button>
-            {workout.id && (
-              <button onClick={this.handleDeleteWorkout}>delete workout</button>
-            )}
-          </div>
-        </form>
-      </div>
+            <label>
+              <select
+                name="exercise"
+                id="exercise-select"
+                onChange={this.addExercise}
+              >
+                <option value="">add exercises</option>
+                {availableExercises.map((exercise: Exercise, index) => {
+                  return (
+                    <option key={index} value={exercise.id}>
+                      {exercise.name}
+                      {exercise.description && " - "}
+                      {exercise.description}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+            <div>
+              <button type="submit">{workout.id ? "update" : "create"}</button>
+              {workout.id && (
+                <button onClick={this.handleDeleteWorkout}>delete</button>
+              )}
+            </div>
+          </form>
+        </div>
+      </section>
     );
   }
 }


### PR DESCRIPTION
Cleaned up the layout for the workout editor:
- moved color picked next to title
- made the title and description inline fields
<img width="628" alt="Workout editor" src="https://user-images.githubusercontent.com/1589186/74627711-90412c80-5108-11ea-84bf-e64649079906.png">

Cleaned up the list of Exercises:
- No longer using bullet points
<img width="620" alt="Exercises" src="https://user-images.githubusercontent.com/1589186/74627713-90412c80-5108-11ea-911f-71fad1489930.png">

Put the user icon inline with the app title:
<img width="620" alt="user icon in title" src="https://user-images.githubusercontent.com/1589186/74627706-8fa89600-5108-11ea-9bb8-fe4f9c6eab2e.png">
