### PR TITLE
paginate entries

### DIFF
--- a/src/Database.tsx
+++ b/src/Database.tsx
@@ -179,7 +179,7 @@ export async function watchEntries(onEntriesChange) {
     snapshot.query
       .orderBy("entryTime", "desc")
       .where("userid", "==", REFS && REFS.user ? REFS.user.id : "")
-      .limit(10) // TODO paginate instead of arbitrary limit
+      .limit(5)
       .get()
       .then(result =>
         snapshotToList(result).then(list => {
@@ -189,11 +189,24 @@ export async function watchEntries(onEntriesChange) {
   });
 }
 
-export async function getRecentEntries() {
-  const snapshot = await REFS.entries
-    .orderBy("entryTime", "desc")
-    .limit(10) // TODO paginate instead of arbitrary limit
-    .get();
+export async function getRecentEntries(startAfter: Date, userId?: string) {
+  let snapshot: firestore.QuerySnapshot;
+  if (!!userId) {
+    // gets recent entries from only one person
+    snapshot = await REFS.entries
+      .orderBy("entryTime", "desc")
+      .where("userid", "==", userId)
+      .startAfter(startAfter)
+      .limit(5)
+      .get();
+  } else {
+    // get recent entries by anyone
+    snapshot = await REFS.entries
+      .orderBy("entryTime", "desc")
+      .startAfter(startAfter)
+      .limit(5)
+      .get();
+  }
   const entries = await snapshotToList(snapshot);
   return entries;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-import { firestore } from "firebase/app"; // types
+import { firestore, User as FUser } from "firebase/app"; // types
+
+export type FirestoreUser = FUser;
 
 export type User = {
   imgSrc: string;


### PR DESCRIPTION
At the bottom of every list is the ability to look further into the list.

![Screen Shot 2020-02-19 at 21 44 43](https://user-images.githubusercontent.com/1589186/74904706-51f27a00-5361-11ea-9dc3-90c5362bb195.png)

Use firebase's `limit` and `startAfter` query clauses to paginate (page through) entries, so that we don't have to load an overwhelming amount at once.