### PR TITLE
Create a yearly review page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -295,3 +295,10 @@ ul.description-list {
     color: #ece8f2;
   }
 }
+
+.banner {
+  background: linear-gradient(27deg, rgba(255, 234, 165, 1) 0%, rgba(170, 255, 235, 1) 100%);
+  padding: 5px 10px;
+  margin: 0 -15px;
+  margin-bottom: 10px;
+}

--- a/src/Classes.tsx
+++ b/src/Classes.tsx
@@ -58,7 +58,7 @@ export class Entry {
 // https://firebase.google.com/docs/reference/js/firebase.firestore.FirestoreDataConverter
 export const entryConverter = {
   toFirestore(entry: Entry): firebase.firestore.DocumentData {
-    return {};
+    return {}; // TODO
   },
   fromFirestore(
     snapshot: firebase.firestore.QueryDocumentSnapshot,
@@ -77,5 +77,43 @@ export const entryConverter = {
   },
 };
 
-const Classes = {}
+export class YearlyReview {
+  readonly updated: Date;
+  creator?: User;
+
+  constructor(
+    updated: firestore.Timestamp,
+    readonly workoutTotals: {},
+    readonly creatorRef: firestore.DocumentReference,
+    readonly year: Number,
+    readonly id: string
+  ) {
+    this.updated = updated.toDate();
+  }
+
+  toString(): string {
+    return `year ${this.year} in review`;
+  }
+}
+
+export const yearlyReviewConverter = {
+  toFirestore(yearlyReview: YearlyReview): firebase.firestore.DocumentData {
+    return {}; // TODO
+  },
+  fromFirestore(
+    snapshot: firebase.firestore.QueryDocumentSnapshot,
+    options: firebase.firestore.SnapshotOptions
+  ): YearlyReview {
+    const data = snapshot.data(options)!;
+    return new YearlyReview(
+      data.updated,
+      data.workoutTotals,
+      data.creator,
+      data.year,
+      snapshot.id
+    );
+  },
+};
+
+const Classes = {};
 export default Classes;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -9,6 +9,7 @@ import Encouragements, {
 import Exercises from "./Exercises";
 import Workouts from "./Workouts";
 import Journal, { Entries } from "./Journal";
+import YearlyReview from "./YearlyReview";
 import { Link } from "./History";
 import { User } from "./types";
 
@@ -21,6 +22,7 @@ export type PageProps = {
 
 const Home = (props: PageProps) => (
   <div>
+    {props.page !== "yearlyreview" && <YearInReviewBanner />}
     <Navigation page={props.page} />
     <RandomEncouragement />
     <Page {...props} subpaths={getSubpaths(window.location.pathname)} />
@@ -64,6 +66,12 @@ const Page = ({ page, ...props }: PageProps) => {
           <Workouts />
         </div>
       );
+    case "yearlyreview":
+      return (
+        <div>
+          <YearlyReview {...props} />
+        </div>
+      );
     case "":
       // TODO the group journal should show the next n entries, rather than by time window.
       return (
@@ -75,6 +83,12 @@ const Page = ({ page, ...props }: PageProps) => {
       return <div>nothing to see here :^)</div>;
   }
 };
+
+const YearInReviewBanner = () => (
+  <div className="banner">
+    Check out your <Link href="/yearlyreview">2020 year of growing</Link> 🌱
+  </div>
+);
 
 const Navigation = ({ page }) => (
   <div className="list-row">

--- a/src/YearlyReview.tsx
+++ b/src/YearlyReview.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { firestore } from "firebase";
+import moment from "moment";
+import { Workout, YearlyReview, FirestoreUser } from "./types";
+import {
+  watchWorkouts,
+  watchYearlyReview,
+  createYearlyReview,
+} from "./Database";
+
+const LAST_YEAR = 2020;
+
+type ReviewState = {
+  workouts: Array<Workout>;
+  yearlyReview?: YearlyReview;
+  cancelWorkoutsWatcher: () => void;
+  cancelYearlyReviewWatcher: () => void;
+};
+export default class Review extends React.Component<
+  {
+    user: FirestoreUser;
+  },
+  ReviewState
+> {
+  state = {
+    workouts: [],
+    cancelWorkoutsWatcher: () => {},
+    cancelYearlyReviewWatcher: () => {},
+    yearlyReview: undefined,
+  };
+
+  constructor(props) {
+    super(props);
+    let cancelWorkoutsWatcher;
+    watchWorkouts(this.handleWorkoutsChange).then((fn) => {
+      cancelWorkoutsWatcher = fn;
+      this.setState({ cancelWorkoutsWatcher });
+    });
+
+    let cancelYearlyReviewWatcher;
+    watchYearlyReview(
+      this.handleYearlyReviewChange,
+      props.user.uid,
+      LAST_YEAR
+    ).then((fn) => {
+      cancelYearlyReviewWatcher = fn;
+      this.setState({ cancelYearlyReviewWatcher });
+    });
+  }
+
+  componentWillUnmount() {
+    this.state.cancelWorkoutsWatcher();
+    this.state.cancelYearlyReviewWatcher();
+  }
+
+  handleWorkoutsChange = (workouts: Array<Workout>) => {
+    this.setState({ workouts });
+  };
+
+  handleYearlyReviewChange = async (
+    reviewsSnapshot: firestore.QuerySnapshot
+  ) => {
+    const reviews: YearlyReview[] = [];
+    reviewsSnapshot.forEach((doc) => reviews.push(doc.data() as YearlyReview));
+
+    if (!reviews.length) {
+      createYearlyReview(this.props.user.uid, LAST_YEAR);
+    } else if (reviews.length === 1) {
+      this.setState({ yearlyReview: reviews[0] });
+    } else {
+      console.log(
+        "something is wrong, there should only be one review per year. TODO implement error reporting haha"
+      );
+    }
+  };
+
+  countWorkouts = (workouts, workoutTotals): Array<WorkoutSummary> => {
+    if (!workoutTotals || !Object.keys(workoutTotals)) {
+      return [];
+    }
+
+    const workoutsWithCounts: Array<any> = [];
+    workouts.forEach((workout) => {
+      const w = workout as Workout;
+      if (w.id) {
+        const data: WorkoutSummary = {
+          workout: w,
+          yearCount: workoutTotals[w.id] || 0,
+        };
+        workoutsWithCounts.push(data);
+      } else {
+        console.log("can't process workout, id is missing.");
+      }
+    });
+
+    workoutsWithCounts.sort(
+      (a: WorkoutSummary, b: WorkoutSummary) => b.yearCount - a.yearCount
+    );
+
+    return workoutsWithCounts;
+  };
+
+  render() {
+    const { yearlyReview, workouts } = this.state;
+    const workoutTotals = yearlyReview ? yearlyReview.workoutTotals : {};
+    const workoutSummaries = this.countWorkouts(workouts, workoutTotals);
+
+    return (
+      <React.Fragment>
+        <section>
+          <div className="banner" style={{ padding: "15px" }}>
+            <h2>Your year in review 🎉</h2>
+            {yearlyReview && (
+              <p>
+                {yearlyReview.year} was kind of a lot. Here's how you grew
+                despite everything:
+              </p>
+            )}
+          </div>
+          {workoutSummaries.map((summary) => (
+            <WorkoutReport key={summary.workout.id} summary={summary} />
+          ))}
+        </section>
+      </React.Fragment>
+    );
+  }
+}
+type WorkoutSummary = {
+  workout: Workout;
+  yearCount: number;
+};
+
+const WorkoutReport = ({ summary }: { summary: WorkoutSummary }) => {
+  const weeklyAverage = (
+    summary.yearCount / moment([LAST_YEAR]).weeksInYear()
+  ).toFixed(1);
+  return (
+    <div>
+      <h4>{summary.workout.title}</h4>
+      <p>💪 you did this {summary.yearCount} times</p>
+      <p>
+        🌱 which is {weeklyAverage} times per week.
+        {weeklyAverage > 1 && " Nice!!"}
+      </p>
+    </div>
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,23 @@ export type Entry = {
   entryTime: Date;
   created?: Date;
 };
+
+export type YearlyReviewFirebase = {
+  updated: firestore.Timestamp;
+  workoutTotals: {
+    // [WorkoutID]: Number; // TODO
+  };
+  userid?: String;
+  creator?: firestore.DocumentReference;
+  year: Number;
+};
+
+export type YearlyReview = {
+  updated: Date;
+  workoutTotals: {
+    // [WorkoutID]: Number; // TODO
+  };
+  userid?: String; // for filtering on the firestore console, since you can't filter by reference there
+  creator?;
+  year: Number;
+};


### PR DESCRIPTION
A simple yearly review page that summarizes your workouts by frequency. Lots of potential here, just wanted to make the page exist and give basic stats!

To minimize reads and calculations, the yearly review is stored in a new collection and is calculated only one time if a user doesn't already have a yearly review entry for the existing year. A good future improvement is for the summaries to be calculated by a cloud function rather than the client.

<img width="625" alt="yearly review screenshot" src="https://user-images.githubusercontent.com/1589186/103731135-4b7ce900-4f99-11eb-8ea4-cd3ec0daa0e7.png">

