### PR TITLE
alphabetize workouts after fetching

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -63,7 +63,7 @@ const Page = ({ page, ...props }: PageProps) => {
     case "workouts":
       return (
         <div>
-          <Workouts />
+          <Workouts {...props} />
         </div>
       );
     case "yearlyreview":

--- a/src/Journal.tsx
+++ b/src/Journal.tsx
@@ -73,6 +73,7 @@ function findWorkoutById(id, workouts: Array<Workout>) {
 
 type JournalState = {
   cancelEntriesWatcher: () => void;
+  cancelWorkoutsWatcher: () => void;
   workouts: Workout[];
   entries: any[];
   hotDates: any;
@@ -90,7 +91,13 @@ export default class Journal extends React.Component<
 > {
   constructor(props) {
     super(props);
-    watchWorkouts(this.handleWorkoutsChange);
+
+    let cancelWorkoutsWatcher;
+    watchWorkouts(this.handleWorkoutsChange, props.user.uid).then((fn) => {
+      cancelWorkoutsWatcher = fn;
+      this.setState({ cancelWorkoutsWatcher });
+    });
+
     let cancelEntriesWatcher;
     watchEntries(this.handleEntriesChange).then((fn) => {
       cancelEntriesWatcher = fn;
@@ -99,6 +106,7 @@ export default class Journal extends React.Component<
 
     this.state = {
       cancelEntriesWatcher,
+      cancelWorkoutsWatcher,
       workouts: [],
       entries: [],
       hotDates: {},
@@ -111,6 +119,7 @@ export default class Journal extends React.Component<
 
   componentWillUnmount() {
     this.state.cancelEntriesWatcher();
+    this.state.cancelWorkoutsWatcher();
   }
 
   handleWorkoutsChange = (workouts: Array<Workout>) => {
@@ -513,6 +522,7 @@ class JournalEntry extends React.PureComponent<
                 return (
                   <option key={workout.id} value={index}>
                     {workout.title}
+                    {workout.emoji && ` ${workout.emoji}`}
                     {workout.description && " - "}
                     {workout.description}
                   </option>

--- a/src/Workouts.tsx
+++ b/src/Workouts.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from "react";
 import { EmojiButton } from "@joeattardi/emoji-button";
-import { Exercise, Workout } from "./types";
+import { Exercise, Workout, User } from "./types";
 import {
   watchExercises,
   watchWorkouts,
@@ -32,13 +32,38 @@ function sortExercises(ids: Array<string>, bank: Array<Exercise>) {
   return [availableExercises, workoutExercises];
 }
 
-export default class Workouts extends React.PureComponent {
-  state = { exerciseBank: [], workouts: [] };
+type WorkoutsProps = {
+  userData: User;
+};
 
+type WorkoutsState = {
+  cancelWorkoutsWatcher: () => void;
+  exerciseBank: Array<Exercise>;
+  workouts: Array<Workout>;
+};
+
+export default class Workouts extends React.PureComponent<
+  WorkoutsProps,
+  WorkoutsState
+> {
   constructor(props) {
     super(props);
+    let cancelWorkoutsWatcher;
     watchExercises(this.handleExercisesChange);
-    watchWorkouts(this.handleWorkoutsChange);
+    watchWorkouts(this.handleWorkoutsChange, props.user.uid).then((fn) => {
+      cancelWorkoutsWatcher = fn;
+      this.setState({ cancelWorkoutsWatcher });
+    });
+
+    this.state = {
+      cancelWorkoutsWatcher,
+      exerciseBank: [],
+      workouts: [],
+    };
+  }
+
+  componentWillUnmount() {
+    this.state.cancelWorkoutsWatcher();
   }
 
   handleExercisesChange = (newExercises: Array<Exercise>) => {

--- a/src/YearlyReview.tsx
+++ b/src/YearlyReview.tsx
@@ -32,7 +32,7 @@ export default class Review extends React.Component<
   constructor(props) {
     super(props);
     let cancelWorkoutsWatcher;
-    watchWorkouts(this.handleWorkoutsChange).then((fn) => {
+    watchWorkouts(this.handleWorkoutsChange, props.user.uid).then((fn) => {
       cancelWorkoutsWatcher = fn;
       this.setState({ cancelWorkoutsWatcher });
     });


### PR DESCRIPTION
It bothers me that workouts aren't alphabetized in the list, it makes them hard to find. You can't use the `.orderBy()` clause of a firebase query because that is case sensitive. That means the capitalised workouts would come before the uncapitalised workouts u_u. To get around this, I just sort in the browser.

I also cleaned up the code to cancel the watchers when components unmount. 