### PR TITLE
remove "year in review" banner for 2020

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -22,7 +22,6 @@ export type PageProps = {
 
 const Home = (props: PageProps) => (
   <div>
-    {props.page !== "yearlyreview" && <YearInReviewBanner />}
     <Navigation page={props.page} />
     <RandomEncouragement />
     <Page {...props} subpaths={getSubpaths(window.location.pathname)} />
@@ -83,12 +82,6 @@ const Page = ({ page, ...props }: PageProps) => {
       return <div>nothing to see here :^)</div>;
   }
 };
-
-const YearInReviewBanner = () => (
-  <div className="banner">
-    Check out your <Link href="/yearlyreview">2020 year of growing</Link> 🌱
-  </div>
-);
 
 const Navigation = ({ page }) => (
   <div className="list-row">

--- a/src/Profile.tsx
+++ b/src/Profile.tsx
@@ -173,7 +173,7 @@ export default class Profile extends React.PureComponent<
 
     return (
       <div className="section">
-        <h3>Profile</h3>
+        <h3>Edit Profile</h3>
         {error && <p style={{ color: "red" }}>{error}</p>}
         <form className="section" onSubmit={this.updateAccount}>
           <label>
@@ -237,6 +237,9 @@ export default class Profile extends React.PureComponent<
             updated {updated.toDateString()} {updated.toLocaleTimeString()}
           </p>
         )}
+        <h3>Previous years in review</h3>
+        <Link href="/yearlyreview">2020</Link>
+        <h3>Account control</h3>
         <p>
           <button className="text-button" onClick={this.handleSignOut}>
             logout


### PR DESCRIPTION
We are done reflecting on last year. (You can still see your yearly reviews by clicking on your profile).