### PR TITLE
configure whether workouts count as physical activity

### DIFF
--- a/src/Database.tsx
+++ b/src/Database.tsx
@@ -191,7 +191,8 @@ export async function createWorkout(
   description,
   exercises,
   emoji,
-  isQuickadd
+  isQuickadd,
+  isPhysicalActivity
 ) {
   const data: Workout = {
     title: title,
@@ -200,6 +201,7 @@ export async function createWorkout(
     userid: REFS.user ? REFS.user.id : "",
     emoji,
     isQuickadd,
+    isPhysicalActivity,
   };
   REFS.workouts.add({ ...data });
 }

--- a/src/Journal.tsx
+++ b/src/Journal.tsx
@@ -48,7 +48,6 @@ function getTileClassName(date, view, hotDates, workouts): string | null {
     const isActive = workoutsForDay.some((workoutRef) => {
       if (workoutRef) {
         const workout = findWorkoutById(workoutRef.id, workouts);
-        console.log(workout, workout?.isPhysicalActivity);
         if (workout?.isPhysicalActivity) {
           return true;
         }
@@ -195,12 +194,6 @@ export default class Journal extends React.Component<
   };
 
   handleActiveStartDateChange = ({ activeStartDate, view }) => {
-    console.log(
-      "handle active start date change",
-      activeStartDate,
-      view,
-      view === "month"
-    );
     if (view !== "month") {
       return;
     }

--- a/src/Journal.tsx
+++ b/src/Journal.tsx
@@ -42,9 +42,20 @@ const CalendarTile = ({ date, view, hotDates, workouts }) => {
   return null;
 };
 
-function getTileClassName(date, view, hotDates): string | null {
+function getTileClassName(date, view, hotDates, workouts): string | null {
   if (view === "month") {
-    if (hotDates[date.toDateString()]) {
+    const workoutsForDay = hotDates[date.toDateString()] || [];
+    const isActive = workoutsForDay.some((workoutRef) => {
+      if (workoutRef) {
+        const workout = findWorkoutById(workoutRef.id, workouts);
+        console.log(workout, workout?.isPhysicalActivity);
+        if (workout?.isPhysicalActivity) {
+          return true;
+        }
+      }
+      return false;
+    });
+    if (isActive) {
       return "calendar-active-day";
     }
   }
@@ -278,7 +289,7 @@ export default class Journal extends React.Component<
             />
           )}
           tileClassName={({ date, view }) =>
-            getTileClassName(date, view, hotDates)
+            getTileClassName(date, view, hotDates, workouts)
           }
         />
         <h4>{startTime.format("LL")}</h4>

--- a/src/Workouts.tsx
+++ b/src/Workouts.tsx
@@ -174,6 +174,7 @@ class EditWorkout extends React.PureComponent<
     const title = form.get("title");
     const description = form.get("description");
     const isQuickadd = form.get("is-quickadd");
+    const isPhysicalActivity = form.get("is-physical-activity");
     const { workout } = this.props;
     const { emoji, exercises } = this.state;
 
@@ -188,10 +189,18 @@ class EditWorkout extends React.PureComponent<
         exercises,
         emoji,
         isQuickadd,
+        isPhysicalActivity,
       });
       this.setState({ error: "", touched: false });
     } else {
-      createWorkout(title, description, exercises, emoji, isQuickadd);
+      createWorkout(
+        title,
+        description,
+        exercises,
+        emoji,
+        isQuickadd,
+        isPhysicalActivity
+      );
       this.setState({ error: "", touched: false });
       event.target.reset();
     }
@@ -275,6 +284,15 @@ class EditWorkout extends React.PureComponent<
                 onChange={this.handleChange}
               />
               journal shortcut
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                name="is-physical-activity"
+                defaultChecked={!workout ? true : workout?.isPhysicalActivity}
+                onChange={this.handleChange}
+              />
+              count towards daily movement
             </label>
             <div>
               <button

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type Workout = {
   color?: string; // deprecated
   emoji?: string; // the ? exists because of schema change.
   isQuickadd?: boolean;
+  isPhysicalActivity?: boolean;
 };
 
 export type EntryFirebase = {


### PR DESCRIPTION
Since adding the feature where days with Workouts are highlighted in celebration, I found the need to differentiate the Workouts which are not actually workouts (such as when I'm tracking a habit). This PR adds a configuration to Workouts to mark them as counting towards daily physical activity or not, which will affect how the calendar highlights each date.

Configure a workout to be a physical activity or not:
<img width="358" alt="configure workout to be a physical activity" src="https://user-images.githubusercontent.com/1589186/105941888-400a6400-6013-11eb-9088-ab56a94e03d7.png">

The pizza does not cause a day to be highlighted as having completed a physical activity:
<img width="340" alt="pizza is not a physical activity" src="https://user-images.githubusercontent.com/1589186/105941892-413b9100-6013-11eb-94d2-e730195c0fd9.png">
