### PR TITLE
Draft: Sync calendar with entries on journal page

### DIFF
--- a/src/Journal.tsx
+++ b/src/Journal.tsx
@@ -177,7 +177,18 @@ export default class Journal extends React.Component<
     const { entriesSnapshot } = this.state;
     const { user } = this.props;
     const startTime = moment(date);
-    const endTime = moment(startTime).subtract(DISPLAY_INTERVAL_DAYS, "days");
+    const days_ahead_of_month_start = startTime.diff(
+      moment(startTime).startOf("month"),
+      "day",
+      true
+    );
+    const is_close_to_month_start =
+      days_ahead_of_month_start < DISPLAY_INTERVAL_DAYS;
+    // Initially show entries from only this month if entries
+    // within display interval cross over into previous month
+    const endTime = is_close_to_month_start
+      ? moment(startTime).startOf("month")
+      : moment(startTime).subtract(DISPLAY_INTERVAL_DAYS, "days");
 
     if (entriesSnapshot) {
       this.setState({ isLoading: true });

--- a/src/Journal.tsx
+++ b/src/Journal.tsx
@@ -214,6 +214,16 @@ export default class Journal extends React.Component<
       moment(activeStartDate).endOf("month"),
       moment(activeStartDate)
     );
+
+    // if active date is in current month in time,
+    // use today (i.e., latest entry). Otherwise, use end of month
+    const today = moment();
+    const monthDiff = today.diff(activeStartDate, "month", true);
+    if (monthDiff <= 1 && monthDiff > 0) {
+      this.handleNewDateClick(today, null);
+    } else {
+      this.handleNewDateClick(moment(activeStartDate).endOf("month"), null);
+    }
   };
 
   fetchHotDates = async (start: moment.Moment, end: moment.Moment) => {


### PR DESCRIPTION
Currently adds two things:

1. **Shows you entries from the month you switch to**
    If you switch to another month, no longer will it continue to display the entry from the last date that you clicked. It will now default to showing you entries starting from the end of the month.
    ![Kapture 2022-09-21 at 13 31 14](https://user-images.githubusercontent.com/15271107/191605991-022f783c-241d-412e-a3ad-16f3c243d423.gif)

2. **Cut off entries at beginning of month**
    If you clicked on an entry near the beginning of the month, you might have gotten some entries from last month mixed in. It was hard to tell which entries were from which month. Now, it will make sure to only show you entries from the current month after you click the calendar, unless you elect to load more past entries.
    ![Kapture 2022-09-21 at 13 44 02](https://user-images.githubusercontent.com/15271107/191606919-75a24ae0-c5e5-480e-9275-3fd00967da58.gif)

Things to look into:
- Relative time headers for the journal (e.g., "Today", "last week", "last month", "Apr 2021") and also sprinkled throughout the timeline
- Only show the entry from that day when you click a date? If you clicked on a day without anything going on you would expect to see nothing, but we currently will see any past entries. That might be confusing.
- Feels a little weird to display entries starting from the end of the month when switching to months. I almost expect the ordering to be from the beginning, but that doesn't really make sense either. Then again, I don't look primarily at the journal when I switch months... Anything different we can do here? Perhaps not show anything until a user clicks to keep their focus on the calendar?
